### PR TITLE
added Sentiment Analysis Node

### DIFF
--- a/modules/azureCS/README.md
+++ b/modules/azureCS/README.md
@@ -7,14 +7,19 @@ This model needs several **CognigySecrets** to be defined and passed to the Node
 You will require the following Secrets for the respective Nodes:
 
 - **Spellcheck**
-  - key (API Key)
-- **Named Entity Recognition**, **Extract Keyphrases**, **Recognize Language**
-  - key (API Key)
-  - region (Azure Region)
+
+  - Set the **key** to the value "key" and insert the **Cognitive Services API Key** as value
+- **Named Entity Recognition**, **Extract Keyphrases**, **Recognize Language**, **Sentiment Analysis**
+
+  - Set the **key** to the value "key" and insert the **Text Analytics API Key** as value
+
+  - Set the **key** to the value "region" and insert the  **Azure Region** as value
 - **Bing Web Search**, **Bing News Search**
-  - key (API Key)
+
+  - Set the **key** to the value "key" and insert the **Bing Search API Key** as value
 - **Text Translator**
-  - key (API Key)
+
+  - Set the **key** to the value "key" and insert the  **Translator Text API Key** as value
 
 ## Node: Spell Check
  [Resource](https://docs.microsoft.com/de-de/azure/cognitive-services/bing-spell-check/quickstarts/nodejs) 
@@ -237,3 +242,23 @@ Example sentence: *Cognigy is a company from Düsseldorf in Germany.*
     }
   ]
 ```
+
+## Node: Sentiment Analysis
+
+This node returns the sentiment score of a given **text** in a specific **language**. The result is stored in the CognigyContext.
+
+Example sentence: *I love you my son.*
+language: "de"
+
+```json
+"sentiment": {
+    "documents": [
+      {
+        "id": "1",
+        "score": 0.6946889162063599
+      }
+    ],
+    "errors": []
+  }
+```
+

--- a/modules/azureCS/package-lock.json
+++ b/modules/azureCS/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "AzureCS",
+  "name": "azure-cs",
   "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/modules/azureCS/package-lock.json
+++ b/modules/azureCS/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Azure-CS",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/modules/azureCS/package-lock.json
+++ b/modules/azureCS/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "Azure-CS",
+  "name": "AzureCS",
   "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "10.12.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.20.tgz",
-      "integrity": "sha512-9spv6SklidqxevvZyOUGjZVz4QRXGu2dNaLyXIFzFYZW0AGDykzPRIUFJXTlQXyfzAucddwTcGtJNim8zqSOPA==",
+      "version": "10.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
+      "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==",
       "dev": true
     },
     "ajv": {
@@ -388,9 +388,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/modules/azureCS/package.json
+++ b/modules/azureCS/package.json
@@ -4,7 +4,10 @@
   "description": "Microsoft Azure Cognitive Services Custom Module (Language, Search API)",
   "main": "build/module.js",
   "scripts": {
-    "build": "tsc -p ."
+    "transpile": "tsc -p .",
+    "zip": "zip azure.zip build/* package.json package-lock.json README.md icon.png icon-large.png",
+    "build": "npm run transpile && npm run lint && npm run zip",
+    "lint": "tslint -c tslint.json src/**/*.ts"
   },
   "repository": {
     "type": "git",

--- a/modules/azureCS/package.json
+++ b/modules/azureCS/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AzureCS",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Microsoft Azure Cognitive Services Custom Module (Language, Search API)",
   "main": "build/module.js",
   "scripts": {

--- a/modules/azureCS/package.json
+++ b/modules/azureCS/package.json
@@ -19,7 +19,7 @@
   "author": "Cognigy GmbH",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^10.12.20",
+    "@types/node": "^10.14.6",
     "tslint": "^5.12.1",
     "typescript": "^3.3.3"
   },

--- a/modules/azureCS/package.json
+++ b/modules/azureCS/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "AzureCS",
+  "name": "azure-cs",
   "version": "1.1.0",
   "description": "Microsoft Azure Cognitive Services Custom Module (Language, Search API)",
   "main": "build/module.js",

--- a/modules/azureCS/src/module.ts
+++ b/modules/azureCS/src/module.ts
@@ -544,7 +544,7 @@ async function sentimentAnalysis(input: IFlowInput, args: { secret: CognigySecre
             });
         };
 
-        let getSentiments = function (documents) {
+        let getSentiments = (documents) => {
             let body = JSON.stringify(documents);
 
             let requestParams = {

--- a/modules/azureCS/src/module.ts
+++ b/modules/azureCS/src/module.ts
@@ -20,12 +20,12 @@ async function spellCheck(input: IFlowInput, args: { secret: CognigySecret, text
 
         const host = 'api.cognitive.microsoft.com';
         const path = '/bing/v7.0/spellcheck';
-        const query_string = `?mkt=${args.language}&mode=proof`;
+        const queryString = `?mkt=${args.language}&mode=proof`;
 
-        const request_params = {
+        const requestParams = {
             method: 'POST',
             hostname: host,
-            path: path + query_string,
+            path: path + queryString,
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
                 'Content-Length': args.text.length + 5,
@@ -33,7 +33,7 @@ async function spellCheck(input: IFlowInput, args: { secret: CognigySecret, text
             }
         };
 
-        const response_handler = (response) => {
+        const responseHandler = (response) => {
             let body = '';
             response.on('data', (d) => {
                 body += d;
@@ -58,7 +58,7 @@ async function spellCheck(input: IFlowInput, args: { secret: CognigySecret, text
             });
         };
 
-        const req = https.request(request_params, response_handler);
+        const req = https.request(requestParams, responseHandler);
         req.write("text=" + args.text);
         req.end();
     });
@@ -86,7 +86,7 @@ async function recognizeLanguage(input: IFlowInput, args: { secret: CognigySecre
         const uri = `${args.secret.region}.api.cognitive.microsoft.com`;
         const path = '/text/analytics/v2.0/languages';
 
-        const response_handler = (response) => {
+        const responseHandler = (response) => {
             let body = '';
             response.on('data', (d) => {
                 body += d;
@@ -111,10 +111,10 @@ async function recognizeLanguage(input: IFlowInput, args: { secret: CognigySecre
             });
         };
 
-        const get_language = (documents) => {
+        const getLanguage = (documents) => {
             let body = JSON.stringify(documents);
 
-            let request_params = {
+            let requestParams = {
                 method: 'POST',
                 hostname: uri,
                 path: path,
@@ -123,7 +123,7 @@ async function recognizeLanguage(input: IFlowInput, args: { secret: CognigySecre
                 }
             };
 
-            const req = https.request(request_params, response_handler);
+            const req = https.request(requestParams, responseHandler);
             req.write(body);
             req.end();
         };
@@ -134,7 +134,7 @@ async function recognizeLanguage(input: IFlowInput, args: { secret: CognigySecre
             ]
         };
 
-        get_language(documents);
+        getLanguage(documents);
 
     });
 }
@@ -162,7 +162,7 @@ async function extractKeyphrases(input: IFlowInput, args: { secret: CognigySecre
         const uri = `${args.secret.region}.api.cognitive.microsoft.com`;
         const path = '/text/analytics/v2.0/keyPhrases';
 
-        const response_handler = (response) => {
+        const responseHandler = (response) => {
             let body = '';
             response.on('data', (d) => {
                 body += d;
@@ -187,10 +187,10 @@ async function extractKeyphrases(input: IFlowInput, args: { secret: CognigySecre
             });
         };
 
-        const get_key_phrases = (documents) => {
+        const getKeyPhrases = (documents) => {
             let body = JSON.stringify(documents);
 
-            let request_params = {
+            let requestParams = {
                 method: 'POST',
                 hostname: uri,
                 path: path,
@@ -199,7 +199,7 @@ async function extractKeyphrases(input: IFlowInput, args: { secret: CognigySecre
                 }
             };
 
-            const req = https.request(request_params, response_handler);
+            const req = https.request(requestParams, responseHandler);
             req.write(body);
             req.end();
         };
@@ -210,7 +210,7 @@ async function extractKeyphrases(input: IFlowInput, args: { secret: CognigySecre
             ]
         };
 
-        get_key_phrases(documents);
+        getKeyPhrases(documents);
 
     });
 }
@@ -238,7 +238,7 @@ async function namedEntityRecognition(input: IFlowInput, args: { secret: Cognigy
         const uri = `${args.secret.region}.api.cognitive.microsoft.com`;
         const path = '/text/analytics/v2.1-preview/entities';
 
-        const response_handler = (response) => {
+        const responseHandler = (response) => {
             let body = '';
             response.on('data', (d) => {
                 body += d;
@@ -263,10 +263,10 @@ async function namedEntityRecognition(input: IFlowInput, args: { secret: Cognigy
             });
         };
 
-        const get_entities = (documents) => {
+        const getEntities = (documents) => {
             let body = JSON.stringify(documents);
 
-            let request_params = {
+            let requestParams = {
                 method: 'POST',
                 hostname: uri,
                 path: path,
@@ -275,7 +275,7 @@ async function namedEntityRecognition(input: IFlowInput, args: { secret: Cognigy
                 }
             };
 
-            const req = https.request(request_params, response_handler);
+            const req = https.request(requestParams, responseHandler);
             req.write(body);
             req.end();
         };
@@ -286,7 +286,7 @@ async function namedEntityRecognition(input: IFlowInput, args: { secret: Cognigy
             ]
         };
 
-        get_entities(documents);
+        getEntities(documents);
 
     });
 }
@@ -405,7 +405,7 @@ async function bingImageSearch(input: IFlowInput, args: { secret: CognigySecret,
         let result = {};
         let accessKey = args.secret.key;
 
-        const request_params = {
+        const requestParams = {
             method: 'GET',
             hostname: 'api.cognitive.microsoft.com',
             path: `/bing/v7.0/images/search?q=${encodeURIComponent(args.term)}`,
@@ -414,7 +414,7 @@ async function bingImageSearch(input: IFlowInput, args: { secret: CognigySecret,
             }
         };
 
-        const response_handler = (response) => {
+        const responseHandler = (response) => {
             let body = '';
 
             response.on('data', (d) => {
@@ -435,7 +435,7 @@ async function bingImageSearch(input: IFlowInput, args: { secret: CognigySecret,
             });
         };
 
-        const req = https.request(request_params, response_handler);
+        const req = https.request(requestParams, responseHandler);
         req.end();
     });
 }
@@ -519,7 +519,7 @@ async function sentimentAnalysis(input: IFlowInput, args: { secret: CognigySecre
         const uri = `${args.secret.region}.api.cognitive.microsoft.com`;
         const path = '/text/analytics/v2.0/sentiment';
 
-        const response_handler = (response) => {
+        const responseHandler = (response) => {
             let body = '';
             response.on('data', (d) => {
                 body += d;
@@ -544,10 +544,10 @@ async function sentimentAnalysis(input: IFlowInput, args: { secret: CognigySecre
             });
         };
 
-        let get_sentiments = function (documents) {
+        let getSentiments = function (documents) {
             let body = JSON.stringify(documents);
 
-            let request_params = {
+            let requestParams = {
                 method: 'POST',
                 hostname: uri,
                 path: path,
@@ -556,7 +556,7 @@ async function sentimentAnalysis(input: IFlowInput, args: { secret: CognigySecre
                 }
             };
 
-            let req = https.request(request_params, response_handler);
+            let req = https.request(requestParams, responseHandler);
             req.write(body);
             req.end();
         }
@@ -567,7 +567,7 @@ async function sentimentAnalysis(input: IFlowInput, args: { secret: CognigySecre
             ]
         };
 
-        get_sentiments(documents);
+        getSentiments(documents);
     });
 }
 

--- a/modules/azureCS/src/module.ts
+++ b/modules/azureCS/src/module.ts
@@ -506,7 +506,7 @@ module.exports.textTranslator = textTranslator;
  * @arg {CognigyScript} `store` Where to store the result
  * @arg {Boolean} `stopOnError` Whether to stop on error or continue
  */
-async function sentimentAnalysis(input: IFlowInput, args: { secret: CognigySecret, text: string, language: string, store: string, stopOnError: boolean }): Promise<IFlowInput | {}> {
+async function analyseSentiments(input: IFlowInput, args: { secret: CognigySecret, text: string, language: string, store: string, stopOnError: boolean }): Promise<IFlowInput | {}> {
     // Check if secret exists and contains correct parameters
     if (!args.secret || !args.secret.key || !args.secret.region) return Promise.reject("Secret not defined or invalid.");
     if (!args.text) return Promise.reject("No text defined.");
@@ -571,4 +571,4 @@ async function sentimentAnalysis(input: IFlowInput, args: { secret: CognigySecre
     });
 }
 
-module.exports.sentimentAnalysis = sentimentAnalysis;
+module.exports.analyseSentiments = analyseSentiments;

--- a/modules/azureCS/src/module.ts
+++ b/modules/azureCS/src/module.ts
@@ -81,7 +81,7 @@ async function recognizeLanguage(input: IFlowInput, args: { secret: CognigySecre
 
     return new Promise((resolve, reject) => {
         let result = {};
-        let accessKey = args.secret.key;
+        const accessKey = args.secret.key;
 
         const uri = `${args.secret.region}.api.cognitive.microsoft.com`;
         const path = '/text/analytics/v2.0/languages';
@@ -112,9 +112,9 @@ async function recognizeLanguage(input: IFlowInput, args: { secret: CognigySecre
         };
 
         const getLanguage = (documents) => {
-            let body = JSON.stringify(documents);
+            const body = JSON.stringify(documents);
 
-            let requestParams = {
+            const requestParams = {
                 method: 'POST',
                 hostname: uri,
                 path: path,
@@ -128,7 +128,7 @@ async function recognizeLanguage(input: IFlowInput, args: { secret: CognigySecre
             req.end();
         };
 
-        let documents = {
+        const documents = {
             'documents': [
                 { 'id': '1', 'text': args.text }
             ]
@@ -157,7 +157,7 @@ async function extractKeyphrases(input: IFlowInput, args: { secret: CognigySecre
 
     return new Promise((resolve, reject) => {
         let result = {};
-        let accessKey = args.secret.key;
+        const accessKey = args.secret.key;
 
         const uri = `${args.secret.region}.api.cognitive.microsoft.com`;
         const path = '/text/analytics/v2.0/keyPhrases';
@@ -188,9 +188,9 @@ async function extractKeyphrases(input: IFlowInput, args: { secret: CognigySecre
         };
 
         const getKeyPhrases = (documents) => {
-            let body = JSON.stringify(documents);
+            const body = JSON.stringify(documents);
 
-            let requestParams = {
+            const requestParams = {
                 method: 'POST',
                 hostname: uri,
                 path: path,
@@ -204,7 +204,7 @@ async function extractKeyphrases(input: IFlowInput, args: { secret: CognigySecre
             req.end();
         };
 
-        let documents = {
+        const documents = {
             'documents': [
                 { 'id': '1', 'language': args.language, 'text': args.text }
             ]
@@ -233,7 +233,7 @@ async function namedEntityRecognition(input: IFlowInput, args: { secret: Cognigy
 
     return new Promise((resolve, reject) => {
         let result = {};
-        let accessKey = args.secret.key;
+        const accessKey = args.secret.key;
 
         const uri = `${args.secret.region}.api.cognitive.microsoft.com`;
         const path = '/text/analytics/v2.1-preview/entities';
@@ -264,9 +264,9 @@ async function namedEntityRecognition(input: IFlowInput, args: { secret: Cognigy
         };
 
         const getEntities = (documents) => {
-            let body = JSON.stringify(documents);
+            const body = JSON.stringify(documents);
 
-            let requestParams = {
+            const requestParams = {
                 method: 'POST',
                 hostname: uri,
                 path: path,
@@ -280,7 +280,7 @@ async function namedEntityRecognition(input: IFlowInput, args: { secret: Cognigy
             req.end();
         };
 
-        let documents = {
+        const documents = {
             'documents': [
                 { 'id': '1', 'language': args.language, 'text': args.text }
             ]
@@ -308,7 +308,7 @@ async function bingWebSearch(input: IFlowInput, args: { secret: CognigySecret, q
 
     return new Promise((resolve, reject) => {
         let result = {};
-        let accessKey = args.secret.key;
+        const accessKey = args.secret.key;
 
         https.get({
             hostname: 'api.cognitive.microsoft.com',
@@ -335,8 +335,8 @@ async function bingWebSearch(input: IFlowInput, args: { secret: CognigySecret, q
                 result = { "error": err.message };
                 input.input[args.store] = result;
                 resolve(input);
-            })
-        })
+            });
+        });
     });
 }
 
@@ -358,7 +358,7 @@ async function bingNewsSearch(input: IFlowInput, args: { secret: CognigySecret, 
     return new Promise((resolve, reject) => {
         let result = {};
 
-        let accessKey = args.secret.key;
+        const accessKey = args.secret.key;
 
         https.get({
             hostname: 'api.cognitive.microsoft.com',
@@ -382,7 +382,7 @@ async function bingNewsSearch(input: IFlowInput, args: { secret: CognigySecret, 
                 }
 
             });
-        })
+        });
     });
 }
 
@@ -403,7 +403,7 @@ async function bingImageSearch(input: IFlowInput, args: { secret: CognigySecret,
 
     return new Promise((resolve, reject) => {
         let result = {};
-        let accessKey = args.secret.key;
+        const accessKey = args.secret.key;
 
         const requestParams = {
             method: 'GET',
@@ -458,7 +458,7 @@ async function textTranslator(input: IFlowInput, args: { secret: CognigySecret, 
 
     return new Promise((resolve, reject) => {
         let result = {};
-        let accessKey = args.secret.key;
+        const accessKey = args.secret.key;
 
         const options = {
             method: 'POST',
@@ -514,7 +514,7 @@ async function analyseSentiments(input: IFlowInput, args: { secret: CognigySecre
 
     return new Promise((resolve, reject) => {
         let result = {};
-        let accessKey = args.secret.key;
+        const accessKey = args.secret.key;
 
         const uri = `${args.secret.region}.api.cognitive.microsoft.com`;
         const path = '/text/analytics/v2.0/sentiment';
@@ -544,10 +544,10 @@ async function analyseSentiments(input: IFlowInput, args: { secret: CognigySecre
             });
         };
 
-        let getSentiments = (documents) => {
-            let body = JSON.stringify(documents);
+        const getSentiments = (documents) => {
+            const body = JSON.stringify(documents);
 
-            let requestParams = {
+            const requestParams = {
                 method: 'POST',
                 hostname: uri,
                 path: path,
@@ -556,12 +556,12 @@ async function analyseSentiments(input: IFlowInput, args: { secret: CognigySecre
                 }
             };
 
-            let req = https.request(requestParams, responseHandler);
+            const req = https.request(requestParams, responseHandler);
             req.write(body);
             req.end();
-        }
+        };
 
-        let documents = {
+        const documents = {
             'documents': [
                 { 'id': '1', 'language': args.language, 'text': args.text },
             ]

--- a/modules/azureCS/src/module.ts
+++ b/modules/azureCS/src/module.ts
@@ -20,7 +20,7 @@ async function spellCheck(input: IFlowInput, args: { secret: CognigySecret, text
 
         const host = 'api.cognitive.microsoft.com';
         const path = '/bing/v7.0/spellcheck';
-        const query_string = "?mkt=" + args.language + "&mode=proof";
+        const query_string = `?mkt=${args.language}&mode=proof`;
 
         const request_params = {
             method: 'POST',
@@ -83,7 +83,7 @@ async function recognizeLanguage(input: IFlowInput, args: { secret: CognigySecre
         let result = {};
         let accessKey = args.secret.key;
 
-        const uri = args.secret.region + '.api.cognitive.microsoft.com';
+        const uri = `${args.secret.region}.api.cognitive.microsoft.com`;
         const path = '/text/analytics/v2.0/languages';
 
         const response_handler = (response) => {
@@ -159,7 +159,7 @@ async function extractKeyphrases(input: IFlowInput, args: { secret: CognigySecre
         let result = {};
         let accessKey = args.secret.key;
 
-        const uri = args.secret.region + '.api.cognitive.microsoft.com';
+        const uri = `${args.secret.region}.api.cognitive.microsoft.com`;
         const path = '/text/analytics/v2.0/keyPhrases';
 
         const response_handler = (response) => {
@@ -235,7 +235,7 @@ async function namedEntityRecognition(input: IFlowInput, args: { secret: Cognigy
         let result = {};
         let accessKey = args.secret.key;
 
-        const uri = args.secret.region + '.api.cognitive.microsoft.com';
+        const uri = `${args.secret.region}.api.cognitive.microsoft.com`;
         const path = '/text/analytics/v2.1-preview/entities';
 
         const response_handler = (response) => {
@@ -312,7 +312,7 @@ async function bingWebSearch(input: IFlowInput, args: { secret: CognigySecret, q
 
         https.get({
             hostname: 'api.cognitive.microsoft.com',
-            path: '/bing/v7.0/search?q=' + encodeURIComponent(args.query),
+            path: `/bing/v7.0/search?q=${encodeURIComponent(args.query)}`,
             headers: { 'Ocp-Apim-Subscription-Key': accessKey },
         }, res => {
             let body = '';
@@ -362,7 +362,7 @@ async function bingNewsSearch(input: IFlowInput, args: { secret: CognigySecret, 
 
         https.get({
             hostname: 'api.cognitive.microsoft.com',
-            path: '/bing/v7.0/news/search?q=' + encodeURIComponent(args.term),
+            path: `/bing/v7.0/news/search?q=${encodeURIComponent(args.term)}`,
             headers: { 'Ocp-Apim-Subscription-Key': accessKey },
         }, res => {
             let body = '';
@@ -408,7 +408,7 @@ async function bingImageSearch(input: IFlowInput, args: { secret: CognigySecret,
         const request_params = {
             method: 'GET',
             hostname: 'api.cognitive.microsoft.com',
-            path: '/bing/v7.0/images/search' + '?q=' + encodeURIComponent(args.term),
+            path: `/bing/v7.0/images/search?q=${encodeURIComponent(args.term)}`,
             headers: {
                 'Ocp-Apim-Subscription-Key': accessKey,
             }
@@ -516,7 +516,7 @@ async function sentimentAnalysis(input: IFlowInput, args: { secret: CognigySecre
         let result = {};
         let accessKey = args.secret.key;
 
-        const uri = args.secret.region + '.api.cognitive.microsoft.com';
+        const uri = `${args.secret.region}.api.cognitive.microsoft.com`;
         const path = '/text/analytics/v2.0/sentiment';
 
         const response_handler = (response) => {


### PR DESCRIPTION
Added the Node Sentiment Analysis to the AzureCS Custom Module. With this Node you're able to get the sentiment score of a given sentence in a given language. The result is stored in the Cognigy Context. 

To test this node, upload the AzureCS Custom Module to a project and choose the AzureCS/Sentiment Analysis Node in the Node Picker Menu.

