### PR TITLE
Add upload to azure module

### DIFF
--- a/modules/file-upload-plugin/.gitignore
+++ b/modules/file-upload-plugin/.gitignore
@@ -1,0 +1,2 @@
+
+deploy.json

--- a/modules/file-upload-plugin/README.md
+++ b/modules/file-upload-plugin/README.md
@@ -1,3 +1,40 @@
-Triggers the `file-upload` webchat plugin
+## File Upload Module
 
-See documentation [here](https://github.com/Cognigy/WebchatPlugins/tree/master/plugins/file-upload)
+This Custom Module will allow us to upload files to a third party storage account triggering the ``file-upload`` Webchat [plugin](https://github.com/Cognigy/WebchatPlugins/tree/master/plugins/file-upload), depending on the third party storage used, we will have to set them up accordingly.
+
+## Upload To Microsoft Azure Storage
+
+In order to use the custom module correctly, some items are needed from your Azure Storage account.
+
+* [``Storage Account Name``](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-overview)
+
+This is the name of the account, the URL that this Custom Module uses to give a temporary access to upload data to the storage requires the name of the account, so it is very important to write it correctly.  
+
+* [``Access Key``](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-manage)
+
+This is the value that we will use as a [secret](https://docs.cognigy.com/docs/secrets) in Cognigy, with this you can authorize operations regarding your Azure  Storage account. You can get it in your Azure Storage Account settings under "Access Keys".  
+Note that if you use this key in your project and then you generate a new one in your Azure Storage Account, the old key will no longer be valid, so you will have to put your new key again in your project.
+
+After gathering this data and upload the Custom Module to Cognigy, you will have to create a secret, the key of the secret has to be: 
+
+``key = secret_access_key``  ( literally "secret_access_key" )
+ 
+ and the value  
+ 
+ ``value = <Your account storage "Access Key">``
+ 
+*It is very imprtant to use* **secret_access_key** *as the value of "key", so Cognigy will recognize what you mean by that.*
+
+Now we just need to adjust our node, use the **Upload To Azure Container** node in a flow 
+
+### Upload To Azure Container Node
+
+In this Node some values are required and other optionals. First, we have ``AccountStorageName``, this is the name of your Azure Storage Account and it's required.
+
+Then we have ``ContainerName`` This value is optional, you can leave it blank and it will generate a random id as a name for the container or you can put a name but, you have to be careful how you name it. There are some [rules](https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata) to follow. Be also aware that if a application request to create a container and a container is already created with that name it will ignore it and use the already created container. Please read the documentation from Azure Storage regarding Container and Blobs.
+
+Now we have the ``Secret`` field, you have to select the secret that you created in Cognigy with your Azure Store Account "Access key"
+
+There is also a ``Timeout`` field, it's also optional. Here you can put a number between 1 and 60, this is the time in minutes setting how long will the container upload access token be valid ( the time window in where uploading a file is possible), after this time runs out, it would not be possible to use the token anymore. Another toke has to be created ( the flow must call the node again )
+
+And that is all you need!

--- a/modules/file-upload-plugin/package-lock.json
+++ b/modules/file-upload-plugin/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@toasta/custom-module-scripts": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@toasta/custom-module-scripts/-/custom-module-scripts-1.1.0.tgz",
-			"integrity": "sha512-Spe9xYPpI5NnY/vAKVJkTWaGxOxmNLZd1dNi0ymM5KE8BASzjyhk6z65bMgd+cpnb4Q4V15jIEMwlbKpj8Jkkw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@toasta/custom-module-scripts/-/custom-module-scripts-1.2.0.tgz",
+			"integrity": "sha512-jnFfzFEgwGkOYn+/KATMWI8ONjxEvhdABf0Ro80HsK8TR+7GuKorm4x0HG26WI7EkKDSZhseagiMyJ0Y+/AE9A==",
 			"dev": true,
 			"requires": {
 				"archiver": "^3.1.1",
@@ -377,9 +377,9 @@
 			"dev": true
 		},
 		"end-of-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
 			"dev": true,
 			"requires": {
 				"once": "^1.4.0"

--- a/modules/file-upload-plugin/package.json
+++ b/modules/file-upload-plugin/package.json
@@ -14,9 +14,11 @@
 	"author": "Cognigy GmbH",
 	"license": "MIT",
 	"dependencies": {
-		"aws-sdk": "^2.489.0"
+		"aws-sdk": "^2.489.0",
+		"@azure/storage-blob": "^10.5.0",
+		"uuid": "^3.3.3"
 	},
 	"devDependencies": {
-		"@toasta/custom-module-scripts": "^1.1.0"
+		"@toasta/custom-module-scripts": "^1.2.0"
 	}
 }

--- a/modules/file-upload-plugin/src/module.js
+++ b/modules/file-upload-plugin/src/module.js
@@ -7,8 +7,8 @@
  * @arg {CognigyScript} `bucket` the name of the bucket (default bucket-name)
  * @arg {CognigyScript} `key` name of the bucket key (default uploaded-file)
  */
-async function uploadToAWSBucket(cognigy, { 
-    secret, 
+async function uploadToAWSBucket(cognigy, {
+    secret,
     signatureVersion = 'v4',
     region = 'eu-central-1',
     bucket = 'bucket-name',
@@ -57,6 +57,120 @@ async function uploadToAWSBucket(cognigy, {
     return cognigy;
 }
 
+/**Upload to Azure module */
+
+/**
+ * Prompts a webchat user to upload something to a Azure blob container
+ * @arg {String} `accountStorageName` the name of the Azure Storage account that will be use to upload the file
+ * @arg {CognigyScript} `containerName` the name of the container, if the name is not given then use a random name ()
+ * @arg {SecretSelect} `secret` a secret with an Azure user's secret_access_key
+ */
+async function uploadToAzureContainer(cognigy, {
+    secret,
+    accountStorageName,
+    containerName
+}) {
+
+
+    const {
+        Aborter,
+        AccountSASPermissions,
+        AccountSASResourceTypes,
+        AccountSASServices,
+        SASProtocol,
+        generateAccountSASQueryParameters,
+        ServiceURL,
+        SharedKeyCredential,
+        StorageURL,
+        ContainerURL,
+    } = require('@azure/storage-blob');
+    
+    const uuidv1 = require('uuid/v1');
+
+    const randomName = uuidv1();
+
+    if (!containerName) {
+        containerName = randomName;
+    }
+
+    const { secret_access_key } = secret;
+
+    /**Create Azure blob service object */
+    function getBlobServiceUrl() {
+        const credentials = new SharedKeyCredential(
+            accountStorageName,
+            secret_access_key
+        );
+        const pipeline = StorageURL.newPipeline(credentials);
+        const blobPrimaryURL = `https://${accountStorageName}.blob.core.windows.net/`;
+        return new ServiceURL(blobPrimaryURL, pipeline);
+    }
+
+    const serviceURL = getBlobServiceUrl();
+
+
+    /**Create a new container from the given name, if name was not given, the container name will be the date it was created */
+
+
+    const containerURL = ContainerURL.fromServiceURL(serviceURL, containerName);
+
+    async function createContainer() {
+        try {
+
+            await containerURL.create(Aborter.none);
+
+        } catch (error) {
+            return error;
+        }
+    }
+
+    await createContainer();
+
+    /**SasURL Expiration time */
+
+    const now = new Date();
+    now.setMinutes(now.getMinutes() - 5);
+
+    const tmr = new Date();
+    tmr.setDate(tmr.getDate() + 1);
+
+    // By default, credential is always the last element of pipeline factories
+    const factories = serviceURL.pipeline.factories;
+    const sharedKeyCredential = factories[factories.length - 1];
+
+    /**Create a sasToken */
+
+    const sasToken = generateAccountSASQueryParameters(
+        {
+            expiryTime: tmr,
+            ipRange: { start: '0.0.0.0', end: '255.255.255.255' },
+            permissions: AccountSASPermissions.parse('rwdlacup').toString(),
+            protocol: SASProtocol.HTTPSandHTTP,
+            resourceTypes: AccountSASResourceTypes.parse('sco').toString(),
+            services: AccountSASServices.parse('b').toString(),
+            startTime: now,
+            version: '2019-02-02',
+        },
+        sharedKeyCredential
+    ).toString();
+
+    const baseURL = serviceURL.url;
+    const sasSignature = `?${sasToken}`
+
+    cognigy.actions.output('', {
+        _plugin: {
+            type: 'file-upload',
+            service: 'azure',
+            baseURL,
+            sasSignature,
+            containerName,
+        }
+    });
+
+    return cognigy;
+}
+
 module.exports = {
-    uploadToAWSBucket
+    uploadToAWSBucket,
+    uploadToAzureContainer
 }

--- a/modules/file-upload-plugin/src/module.js
+++ b/modules/file-upload-plugin/src/module.js
@@ -61,10 +61,10 @@ async function uploadToAWSBucket(cognigy, {
 
 /**
  * Prompts a webchat user to upload something to a Azure blob container
- * @arg {String} `accountStorageName` The name of the Azure Storage account that will be use to upload the file
- * @arg {CognigyScript} `containerName` The name of the container, if the name is not given, a random generated id will be used as name
- * @arg {SecretSelect} `secret` The secret with an Azure user's access key. Please name it  "secret_access_key"
- * @arg {Number} `Timeout` The time in minutes that the upload Url used by the Webchat will be availabe, maximum 60 min. ( default 5 min. )
+ * @arg {String} `accountStorageName` The name of the Azure Storage account that will be use to upload the file.
+ * @arg {CognigyScript} `containerName` The name of the container, if the name is not given, a random generated id will be used as name. Only lowercase and numbers are accepted.
+ * @arg {SecretSelect} `secret` The secret access key from  an Azure user's account. Please name the "key" value of the secret "secret_access_key".
+ * @arg {Number} `Timeout` The time in minutes that the upload Url used by the Webchat will be availabe, maximum 60 min. ( default 5 min. ).
  */
 async function uploadToAzureContainer(cognigy, {
     secret,

--- a/modules/file-upload-plugin/src/module.js
+++ b/modules/file-upload-plugin/src/module.js
@@ -74,11 +74,9 @@ async function uploadToAzureContainer(cognigy, {
 
     const {
         Aborter,
-        AccountSASPermissions,
-        AccountSASResourceTypes,
-        AccountSASServices,
+        generateBlobSASQueryParameters,
         SASProtocol,
-        generateAccountSASQueryParameters,
+        ContainerSASPermissions,
         ServiceURL,
         SharedKeyCredential,
         StorageURL,
@@ -138,24 +136,22 @@ async function uploadToAzureContainer(cognigy, {
     const factories = serviceURL.pipeline.factories;
     const sharedKeyCredential = factories[factories.length - 1];
 
-    /**Create a sasToken */
+  /**Create a sasToken */
 
-    const sasToken = generateAccountSASQueryParameters(
-        {
-            expiryTime: tmr,
-            ipRange: { start: '0.0.0.0', end: '255.255.255.255' },
-            permissions: AccountSASPermissions.parse('rwdlacup').toString(),
-            protocol: SASProtocol.HTTPSandHTTP,
-            resourceTypes: AccountSASResourceTypes.parse('sco').toString(),
-            services: AccountSASServices.parse('b').toString(),
-            startTime: now,
-            version: '2019-02-02',
-        },
-        sharedKeyCredential
-    ).toString();
+  const containerSAS = generateBlobSASQueryParameters({
+    containerName, // Required
+    permissions: ContainerSASPermissions.parse("racwdl").toString(), // Required
+    startTime: new Date(), // Required
+    expiryTime: tmr, // Optional. Date type
+    ipRange: { start: "0.0.0.0", end: "255.255.255.255" }, // Optional
+    protocol: SASProtocol.HTTPSandHTTP, // Optional
+    version: "2016-05-31" // Optional
+     },
+     sharedKeyCredential
+   ).toString();
 
     const baseURL = serviceURL.url;
-    const sasSignature = `?${sasToken}`
+    const sasSignature = `?${containerSAS}`
 
     cognigy.actions.output('', {
         _plugin: {

--- a/modules/file-upload-plugin/src/module.js
+++ b/modules/file-upload-plugin/src/module.js
@@ -130,10 +130,14 @@ async function uploadToAzureContainer(cognigy, {
 
     const end = new Date();
 
+    let timeOut = 5;
+
     if( Timeout && Timeout <= 60 ) {
-        end.setMinutes(end.getMinutes() + Timeout);
+        timeOut = Timeout;
     }
 
+    end.setMinutes(end.getMinutes() + timeOut);
+    
     // By default, credential is always the last element of pipeline factories
     const factories = serviceURL.pipeline.factories;
     const sharedKeyCredential = factories[factories.length - 1];

--- a/modules/file-upload-plugin/src/trigger.js
+++ b/modules/file-upload-plugin/src/trigger.js
@@ -1,4 +1,4 @@
-const { uploadToAWSBucket } = require('./module');
+const { uploadToAWSBucket, uploadToAzureContainer } = require('./module');
  
 const cognigyMock = {
     actions: {
@@ -7,6 +7,10 @@ const cognigyMock = {
 }
 
 uploadToAWSBucket(cognigyMock, {
+    json: ''
+});
+
+uploadToAzureContainer(cognigyMock, {
     json: ''
 });
 


### PR DESCRIPTION
This custom module will take care of creating a new Blob container in the Azure storage of the given account and proportionate a Shared Access Service Url to allow an anonymous user to upload a file in a time window  through the WebchatPlugin 'file-upload-plugin'.

It also generates the corresponding Node to be used in Cognigy.

To test, import the Custom Module in cognigy, create a Flow and add the node Upload To Azure Container. Provide the name of the storage account and the Access Key, a name for the container is optional.